### PR TITLE
Add DomScan domain search tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Awesome list of Search Engines for Cybersecurity Researchers
 | https://dbugs.ptsecurity.com/ | New home for vulnerabilities. More than CVEs. More than MITRE.[Trends & Insights - AI-generated, multi-source vulnerability descriptions - Researcher credits] | NO |
 | https://magnify.modat.io/ | Modat Magnify gives you access to the largest internet device DNA dataset available. | Yes |
 | https://subdomainradar.io/ | Discover hidden subdomains, retrieve IP/DNS data, verify URLs, scan ports, capture screenshots, and scan for vulnerabilities—all in one powerful platform. | Yes |
+| https://domscan.net/tools/security | Search domain intelligence across DNS, WHOIS/RDAP, TLS, subdomains, reputation, redirects, technology, and typosquatting. | Yes |
 | https://leakradar.io | Search over 6 billion plain text credentials harvested by malware and get alerted before attackers act. | Yes |
 | https://meawfy.com/ | Search and discover files from Mega.nz with our intelligent crawler technology. Access over 9 million indexed files instantly. | NO |
 | https://www.eyedex.org/ | Search in 2.3 PB of 18,731,438 files among 5,171,742 directories on 114 servers | NO |


### PR DESCRIPTION
Adds DomScan as a cybersecurity research search resource with API access.\n\nIt covers public domain intelligence across DNS, WHOIS/RDAP, TLS, subdomains, reputation, redirects, technology detection, and typosquatting.\n\nDisclosure: I maintain DomScan.