### PR TITLE
Add SearchWebCode (source-code search engine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Awesome list of Search Engines for Cybersecurity Researchers
 | https://hunter.io/ | Search for email addresses belonging to a website | YES |
 | https://www.wigle.net/ | Database of wireless networks, with statistics | YES |
 | https://publicwww.com/ | Marketing and affiliate marketing research | YES |
+| https://www.searchwebcode.com/ | Exact-string and regex search across the HTML, JS and CSS source of 129M website homepages | YES |
 | https://censys.io/ | Assessing attack surface for internet connected devices | YES |
 | https://netlas.io/ | Search and monitor internet connected assets | YES |
 | https://fofa.info/ | Search for various threat intelligence | YES |


### PR DESCRIPTION
[SearchWebCode](https://www.searchwebcode.com) is an exact-string and regex search engine over the HTML, JS and CSS source of ~129M website homepages — a source-code search engine in the same category as PublicWWW and NerdyData, which this list already includes. Every result opens the full matched page source, and the matching domain list is exportable as CSV.

Added it next to the existing source-code search entry.

Disclosure: I'm affiliated with the project.